### PR TITLE
vmxserver: Add threshold to discard optional packets

### DIFF
--- a/src/vmxserver-client.h
+++ b/src/vmxserver-client.h
@@ -1,12 +1,15 @@
 #pragma once
 
+#include "vmxprop.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct vmxserver_client_s vmxserver_client_t;
 
-vmxserver_client_t *vmxserver_client_create(int sock, uint32_t proxy_flags, socket_moderator_t *ss, proxycore_t *p);
+vmxserver_client_t *vmxserver_client_create(int sock, uint32_t proxy_flags, socket_moderator_t *ss, proxycore_t *p,
+					    vmx_prop_ref_t prop);
 void vmxserver_client_destroy(vmxserver_client_t *c);
 bool vmxserver_client_has_error(vmxserver_client_t *c);
 

--- a/src/vmxserver.cc
+++ b/src/vmxserver.cc
@@ -27,6 +27,7 @@ struct vmxserver_s
 	std::string name;
 	std::list<vmxserver_client_t *> clients;
 	int port_listen;
+	vmx_prop_t prop;
 };
 
 void vmxserver_set_prop(vmxserver_t *s, vmx_prop_ref_t prop)
@@ -34,6 +35,7 @@ void vmxserver_set_prop(vmxserver_t *s, vmx_prop_ref_t prop)
 	s->primary = prop.get<bool>("primary", false);
 	s->name = prop.get<std::string>("name", "M-200i-1");
 	s->port_listen = prop.get<int>("port", 0);
+	s->prop = prop;
 }
 
 vmxserver_t *vmxserver_create(vmx_prop_ref_t prop)
@@ -143,7 +145,7 @@ static void process_connection(struct vmxserver_s *s)
 		proxy_flags |= PROXYCORE_INSTANCE_PRIMARY;
 	else
 		proxy_flags |= PROXYCORE_INSTANCE_SECONDARY;
-	auto c = vmxserver_client_create(sock, proxy_flags, s->ss, s->proxy);
+	auto c = vmxserver_client_create(sock, proxy_flags, s->ss, s->proxy, s->prop);
 	if (c)
 		s->clients.push_back(c);
 }


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

If the packet address is 0x10100100, and if the send queue has larger data configured by a property, discard the packet.

Based on an analysis, 0x10100100 is the most frequently updated address and it looks the information for the level meter so that it is ok to just discard.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

1. Start the server with the JSON file below. This will connect to M-200i.
2. Connect iPad application to `M-200i-Proxy`.
3. Checked the level meters for a while.
   Confirmed the frequency of the connection failures was reduced than that without this modification.

```json
{
  "host": {
    "host": "192.0.2.2",
    "port": 33752
  },
  "servers": [
    {
      "primary": true,
      "port": 33752,
      "name": "M-200i-Proxy",
      "send_buf_thresh": 360
    }
  ]
}
```

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
